### PR TITLE
Change for win paths

### DIFF
--- a/src/ComponentPackages.jl
+++ b/src/ComponentPackages.jl
@@ -79,8 +79,12 @@ module ComponentPackages
             error("undefined package $(package_symbol)")
         end
         package = _components_packages[Symbol(package_name)]
-        source_path = Sys.iswindows() ? replace(package.source_path[2:end-1], "/" =>"\\") : package.source_path 
-        meta_filename = joinpath(ROOT_PATH, source_path, "metadata.json") 
+        
+        meta_filename = joinpath(
+            ROOT_PATH, 
+            Sys.iswindows() ? replace(package.source_path[2:end-1], "/" =>"\\") : package.source_path,
+            "metadata.json"
+        ) 
         return load_components_meta(meta_filename)
         raw_meta = JSON.parsefile(meta_filename, dicttype = OrderedDict{String, Any})
         components = Dict{Symbol, ComponentMeta}()

--- a/src/ComponentPackages.jl
+++ b/src/ComponentPackages.jl
@@ -1,12 +1,12 @@
 module ComponentPackages
     import JSON, JSON2, HTTP
     
-
+    
     include("ComponentMetas.jl")
     using .ComponentMetas    
     
-    const ROOT_PATH = (@__DIR__) * "/.."
-    const META_FILENAME = ROOT_PATH * "/components_meta.json"    
+    const ROOT_PATH = realpath(joinpath( @__DIR__, ".."))
+    const META_FILENAME = joinpath(ROOT_PATH, "components_meta.json")
 
     struct ComponentPackage
         name ::String
@@ -79,8 +79,8 @@ module ComponentPackages
             error("undefined package $(package_symbol)")
         end
         package = _components_packages[Symbol(package_name)]
-        
-        meta_filename = "$(ROOT_PATH)/$(package.source_path)metadata.json"
+        source_path = Sys.iswindows() ? replace(package.source_path[2:end-1], "/" =>"\\") : package.source_path 
+        meta_filename = joinpath(ROOT_PATH, source_path, "metadata.json") 
         return load_components_meta(meta_filename)
         raw_meta = JSON.parsefile(meta_filename, dicttype = OrderedDict{String, Any})
         components = Dict{Symbol, ComponentMeta}()


### PR DESCRIPTION
Hi! 

I had trouble using Dashboard.jl on Win10 so I made a few changes.

I'm not super happy with the elegance of `Sys.iswindows() ? replace(package.source_path[2:end-1], "/" =>"\\") : package.source_path,` so if you have any suggestions I'll gladly read them ;)

thanks, have a good day