### PR TITLE
Correct path to pick up metadata

### DIFF
--- a/src/ComponentPackages.jl
+++ b/src/ComponentPackages.jl
@@ -82,7 +82,7 @@ module ComponentPackages
         
         meta_filename = joinpath(
             ROOT_PATH, 
-            Sys.iswindows() ? replace(package.source_path[2:end-1], "/" =>"\\") : package.source_path,
+            Sys.iswindows() ? replace(package.source_path[2:end-1], "/" =>"\\") : package.source_path[2:end],
             "metadata.json"
         ) 
         return load_components_meta(meta_filename)


### PR DESCRIPTION
`joinpath` with multiple arguments ignores paths previous to ones that seem to have absolute paths (ie starting with a `/`)

Closes #16 

This is with MacOS, but I'd assume its the same for linux.