### PR TITLE
Use rethrow instead of throw

### DIFF
--- a/src/Dashboards.jl
+++ b/src/Dashboards.jl
@@ -491,7 +491,7 @@ function make_handler(app::Dash; debug::Bool = false)
                 if isa(e,PreventUpdate)                
                     return HTTP.Response(204)                                    
                 else
-                    throw(e)
+                    rethrow(e)
                 end
             end 
         end


### PR DESCRIPTION
This preserves stack traces through the callbacks and makes debugging easier.